### PR TITLE
rename DATABASE_NAME and DATABASE_URL env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,17 +27,24 @@ BUCKET_PATH=bucket_path
 # file path to which backups should be written upon download
 DOWNLOAD_PATH=download_path
 
-# the name of the database where the data will be restored
-DATABASE_NAME=database_name
+# The name of the database where the data will be restored.
+#
+# If TARGET_DATABASE_URL is not present, a local database with the
+# name set to TARGET_DATABASE_NAME will be the target for restoring data.
+#
+# If TARGET_DATABASE_URL is present, then TARGET_DATABASE_NAME is used
+# as the base of the name of the files that are downloaded from
+# the S3 bucket.
+#
+TARGET_DATABASE_NAME=database_name
 ```
 
 ## Optional
 
 ```
-# the url of the database where the data will be restored
-# if DATABASE_URL is present, then DATABASE_NAME is only used
-# to for as a placeholder name for the backup local backup files
-DATABASE_URL=postgres://user:pass@host/database_name
+# The url of the database where the data will be restored
+#
+TARGET_DATABASE_URL=postgres://user:pass@host/database_name
 ```
 
 ## Example Docker Usage
@@ -54,7 +61,7 @@ docker run --rm -it \
     -e BUCKET_NAME=$BUCKET_NAME \
     -e BUCKET_PATH=$BUCKET_PATH \
     -e DOWNLOAD_PATH=/tmp \
-    -e DATABASE_URL=$DATABASE_URL \
+    -e TARGET_DATABASE_URL=$TARGET_DATABASE_URL \
     -e FORMAT=custom \
     pg_restore_from_s3
 ```

--- a/restore.sh
+++ b/restore.sh
@@ -19,12 +19,12 @@ case $key in
     DOWNLOAD_PATH="$2"
     shift
     ;;
-    -db|--dbname)
-    DATABASE_NAME="$2"
+    -tdb|--target-dbname)
+    TARGET_DATABASE_NAME="$2"
     shift
     ;;
-    -url|--dburl)
-    DATABASE_URL="$2"
+    -turl|--target-dburl)
+    TARGET_DATABASE_URL="$2"
     shift
     ;;
     -f|--format)
@@ -40,12 +40,12 @@ BUCKET_PATH=${BUCKET_PATH:='bucket_path'}
 DOWNLOAD_PATH=${DOWNLOAD_PATH:='./'}
 DB_BACKUP_ENC_KEY=${DB_BACKUP_ENC_KEY:=}
 
-DATABASE_NAME=${DATABASE_NAME:='database_name'}
-DATABASE_URL=${DATABASE_URL:=}
+TARGET_DATABASE_NAME=${TARGET_DATABASE_NAME:='database_name'}
+TARGET_DATABASE_URL=${TARGET_DATABASE_URL:=}
 FORMAT=${FORMAT:=}
 
-if [[ -z "$DATABASE_NAME" ]]; then
-  echo "Missing DATABASE_NAME variable"
+if [[ -z "$TARGET_DATABASE_NAME" ]]; then
+  echo "Missing TARGET_DATABASE_NAME variable"
   exit 1
 fi
 if [[ -z "$AWS_ACCESS_KEY_ID" ]]; then
@@ -107,61 +107,61 @@ aws s3 cp s3://$BUCKET_NAME/$BUCKET_PATH/$latest_tar_format $DOWNLOAD_PATH
 
 openssl enc -aes-256-cbc -pbkdf2 -d -pass "env:DB_BACKUP_ENC_KEY" \
   -in $DOWNLOAD_PATH/$latest_custom_format \
-  -out $DOWNLOAD_PATH/${DATABASE_NAME}_custom_format.dump
+  -out $DOWNLOAD_PATH/${TARGET_DATABASE_NAME}_custom_format.dump
 
 openssl enc -aes-256-cbc -pbkdf2 -d -pass "env:DB_BACKUP_ENC_KEY" \
   -in $DOWNLOAD_PATH/$latest_directory_format \
-  -out $DOWNLOAD_PATH/${DATABASE_NAME}_directory_format.tar.gz
+  -out $DOWNLOAD_PATH/${TARGET_DATABASE_NAME}_directory_format.tar.gz
 
 openssl enc -aes-256-cbc -pbkdf2 -d -pass "env:DB_BACKUP_ENC_KEY" \
   -in $DOWNLOAD_PATH/$latest_plain_format \
-  -out $DOWNLOAD_PATH/${DATABASE_NAME}_plain_format.sql.gz
+  -out $DOWNLOAD_PATH/${TARGET_DATABASE_NAME}_plain_format.sql.gz
 
 openssl enc -aes-256-cbc -pbkdf2 -d -pass "env:DB_BACKUP_ENC_KEY" \
   -in $DOWNLOAD_PATH/$latest_tar_format \
-  -out $DOWNLOAD_PATH/${DATABASE_NAME}_tar_format.tar.gz
+  -out $DOWNLOAD_PATH/${TARGET_DATABASE_NAME}_tar_format.tar.gz
 
-if [[ -n "$DATABASE_URL" ]]; then
+if [[ -n "$TARGET_DATABASE_URL" ]]; then
 
-  echo "Restore database using DATABASE_URL"
+  echo "Restore database using TARGET_DATABASE_URL"
 
   # custom format
   if [ -z "$FORMAT" ] || [ "$FORMAT" = "custom" ]; then
     printf "Restoring custom format ...\n"
-    file_path=$DOWNLOAD_PATH/${DATABASE_NAME}_custom_format.dump
-    time pg_restore --clean --no-owner --dbname $DATABASE_URL $file_path
-    psql --dbname $DATABASE_URL --command "\d"
+    file_path=$DOWNLOAD_PATH/${TARGET_DATABASE_NAME}_custom_format.dump
+    time pg_restore --clean --no-owner --dbname $TARGET_DATABASE_URL $file_path
+    psql --dbname $TARGET_DATABASE_URL --command "\d"
   fi
 
   # directory format
   if [ -z "$FORMAT" ] || [ "$FORMAT" = "directory" ]; then
     printf "\n\nRestoring directory format ...\n"
-    dir_path=$DOWNLOAD_PATH/${DATABASE_NAME}_directory_format/
+    dir_path=$DOWNLOAD_PATH/${TARGET_DATABASE_NAME}_directory_format/
     mkdir $dir_path
-    tar -zxvf $DOWNLOAD_PATH/${DATABASE_NAME}_directory_format.tar.gz --strip-components=2 --directory=$dir_path
-    time pg_restore --clean --no-owner --dbname $DATABASE_URL $dir_path
-    psql --dbname $DATABASE_URL --command "\d"
+    tar -zxvf $DOWNLOAD_PATH/${TARGET_DATABASE_NAME}_directory_format.tar.gz --strip-components=2 --directory=$dir_path
+    time pg_restore --clean --no-owner --dbname $TARGET_DATABASE_URL $dir_path
+    psql --dbname $TARGET_DATABASE_URL --command "\d"
   fi
 
   # plain format
   if [ -z "$FORMAT" ] || [ "$FORMAT" = "plain" ]; then
     printf "\n\nRestoring plain format ...\n"
-    gzip --verbose --decompress $DOWNLOAD_PATH/${DATABASE_NAME}_plain_format.sql.gz
-    file_path=$DOWNLOAD_PATH/${DATABASE_NAME}_plain_format.sql
-    time psql --dbname $DATABASE_URL --file=$file_path
-    psql --dbname $DATABASE_URL --command "\d"
+    gzip --verbose --decompress $DOWNLOAD_PATH/${TARGET_DATABASE_NAME}_plain_format.sql.gz
+    file_path=$DOWNLOAD_PATH/${TARGET_DATABASE_NAME}_plain_format.sql
+    time psql --dbname $TARGET_DATABASE_URL --file=$file_path
+    psql --dbname $TARGET_DATABASE_URL --command "\d"
   fi
 
   # tar format
   if [ -z "$FORMAT" ] || [ "$FORMAT" = "tar" ]; then
     printf "\n\nRestoring tar format ...\n"
-    gzip --verbose --decompress $DOWNLOAD_PATH/${DATABASE_NAME}_tar_format.tar.gz
-    file_path=$DOWNLOAD_PATH/${DATABASE_NAME}_tar_format.tar
-    time pg_restore --clean --no-owner --dbname $DATABASE_URL $file_path
-    psql --dbname $DATABASE_URL --command "\d"
+    gzip --verbose --decompress $DOWNLOAD_PATH/${TARGET_DATABASE_NAME}_tar_format.tar.gz
+    file_path=$DOWNLOAD_PATH/${TARGET_DATABASE_NAME}_tar_format.tar
+    time pg_restore --clean --no-owner --dbname $TARGET_DATABASE_URL $file_path
+    psql --dbname $TARGET_DATABASE_URL --command "\d"
   fi
 
-elif [[ -n "$DATABASE_NAME" ]]; then
+elif [[ -n "$TARGET_DATABASE_NAME" ]]; then
 
   if [ -f /.dockerenv ]; then
     printf "\n\n*** Create PGDATA directory at $PGDATA ...\n"
@@ -177,50 +177,50 @@ elif [[ -n "$DATABASE_NAME" ]]; then
     createdb appuser
   fi
 
-  echo "Restore database using DATABASE_NAME"
+  echo "Restore database using TARGET_DATABASE_NAME"
 
   # custom format
   if [ -z "$FORMAT" ] || [ "$FORMAT" = "custom" ]; then
     printf "\n\nRestoring custom format ...\n"
-    file_path=$DOWNLOAD_PATH/${DATABASE_NAME}_custom_format.dump
-    createdb ${DATABASE_NAME}_restored
-    time pg_restore --no-owner --dbname ${DATABASE_NAME}_restored $file_path
-    psql --dbname ${DATABASE_NAME}_restored --command "\d"
-    dropdb ${DATABASE_NAME}_restored
+    file_path=$DOWNLOAD_PATH/${TARGET_DATABASE_NAME}_custom_format.dump
+    createdb ${TARGET_DATABASE_NAME}_restored
+    time pg_restore --no-owner --dbname ${TARGET_DATABASE_NAME}_restored $file_path
+    psql --dbname ${TARGET_DATABASE_NAME}_restored --command "\d"
+    dropdb ${TARGET_DATABASE_NAME}_restored
   fi
 
   # directory format
   if [ -z "$FORMAT" ] || [ "$FORMAT" = "directory" ]; then
     printf "\n\nRestoring directory format ...\n"
-    dir_path=$DOWNLOAD_PATH/${DATABASE_NAME}_directory_format/
+    dir_path=$DOWNLOAD_PATH/${TARGET_DATABASE_NAME}_directory_format/
     mkdir $dir_path
-    tar -zxvf $DOWNLOAD_PATH/${DATABASE_NAME}_directory_format.tar.gz --strip-components=2 --directory=$dir_path
-    createdb ${DATABASE_NAME}_restored
-    time pg_restore --no-owner --dbname ${DATABASE_NAME}_restored $dir_path
-    psql --dbname ${DATABASE_NAME}_restored --command "\d"
-    dropdb ${DATABASE_NAME}_restored
+    tar -zxvf $DOWNLOAD_PATH/${TARGET_DATABASE_NAME}_directory_format.tar.gz --strip-components=2 --directory=$dir_path
+    createdb ${TARGET_DATABASE_NAME}_restored
+    time pg_restore --no-owner --dbname ${TARGET_DATABASE_NAME}_restored $dir_path
+    psql --dbname ${TARGET_DATABASE_NAME}_restored --command "\d"
+    dropdb ${TARGET_DATABASE_NAME}_restored
   fi
 
   # plain format
   if [ -z "$FORMAT" ] || [ "$FORMAT" = "plain" ]; then
     printf "\n\nRestoring plain format ...\n"
-    gzip --verbose --decompress $DOWNLOAD_PATH/${DATABASE_NAME}_plain_format.sql.gz
-    file_path=$DOWNLOAD_PATH/${DATABASE_NAME}_plain_format.sql
-    createdb ${DATABASE_NAME}_restored
-    time psql --dbname ${DATABASE_NAME}_restored --file=$file_path
-    psql --dbname ${DATABASE_NAME}_restored --command "\d"
-    dropdb ${DATABASE_NAME}_restored
+    gzip --verbose --decompress $DOWNLOAD_PATH/${TARGET_DATABASE_NAME}_plain_format.sql.gz
+    file_path=$DOWNLOAD_PATH/${TARGET_DATABASE_NAME}_plain_format.sql
+    createdb ${TARGET_DATABASE_NAME}_restored
+    time psql --dbname ${TARGET_DATABASE_NAME}_restored --file=$file_path
+    psql --dbname ${TARGET_DATABASE_NAME}_restored --command "\d"
+    dropdb ${TARGET_DATABASE_NAME}_restored
   fi
 
   # tar format
   if [ -z "$FORMAT" ] || [ "$FORMAT" = "tar" ]; then
     printf "\n\nRestoring tar format ...\n"
-    gzip --verbose --decompress $DOWNLOAD_PATH/${DATABASE_NAME}_tar_format.tar.gz
-    file_path=$DOWNLOAD_PATH/${DATABASE_NAME}_tar_format.tar
-    createdb ${DATABASE_NAME}_restored
-    time pg_restore --no-owner --dbname ${DATABASE_NAME}_restored $file_path
-    psql --dbname ${DATABASE_NAME}_restored --command "\d"
-    dropdb ${DATABASE_NAME}_restored
+    gzip --verbose --decompress $DOWNLOAD_PATH/${TARGET_DATABASE_NAME}_tar_format.tar.gz
+    file_path=$DOWNLOAD_PATH/${TARGET_DATABASE_NAME}_tar_format.tar
+    createdb ${TARGET_DATABASE_NAME}_restored
+    time pg_restore --no-owner --dbname ${TARGET_DATABASE_NAME}_restored $file_path
+    psql --dbname ${TARGET_DATABASE_NAME}_restored --command "\d"
+    dropdb ${TARGET_DATABASE_NAME}_restored
   fi
 
   if [ -f /.dockerenv ]; then
@@ -236,13 +236,13 @@ rm -v $DOWNLOAD_PATH/$latest_plain_format
 rm -v $DOWNLOAD_PATH/$latest_tar_format
 
 # cleanup each of the unencryped and extracted backups
-rm -v  $DOWNLOAD_PATH/${DATABASE_NAME}_custom_format.dump
-rm -v  $DOWNLOAD_PATH/${DATABASE_NAME}_directory_format.tar.gz
+rm -v  $DOWNLOAD_PATH/${TARGET_DATABASE_NAME}_custom_format.dump
+rm -v  $DOWNLOAD_PATH/${TARGET_DATABASE_NAME}_directory_format.tar.gz
 if [ -z "$FORMAT" ] || [ "$FORMAT" = "directory" ]; then
-  rm -rv $DOWNLOAD_PATH/${DATABASE_NAME}_directory_format/
+  rm -rv $DOWNLOAD_PATH/${TARGET_DATABASE_NAME}_directory_format/
 fi
-rm -v  $DOWNLOAD_PATH/${DATABASE_NAME}_plain_format.*
-rm -v  $DOWNLOAD_PATH/${DATABASE_NAME}_tar_format.*
+rm -v  $DOWNLOAD_PATH/${TARGET_DATABASE_NAME}_plain_format.*
+rm -v  $DOWNLOAD_PATH/${TARGET_DATABASE_NAME}_tar_format.*
 
 # verify empty directory
 printf "\n\nFinal contents of DOWNLOAD_PATH ($DOWNLOAD_PATH) ..."


### PR DESCRIPTION
This PR renames the env vars that specify the destination/target database.

The motivation is to allow this script to be shared in the same environment with a backup script that uses DATABASE_URL or DATABASE_NAME as the 

Clearly, specifying the same DATABASE_URL for both a backup and restore is inviting destruction of data.